### PR TITLE
modif requete hasIrisDescendant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>metadata-api</artifactId>
 	<packaging>war</packaging>
 	<name>Implementation of the RMéS metadata API</name>
-	<version>3.9.4</version>
+	<version>3.9.5-rc0</version>
 	<properties>
 		<java.version>17</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/src/main/java/fr/insee/rmes/utils/IrisUtils.java
+++ b/src/main/java/fr/insee/rmes/utils/IrisUtils.java
@@ -7,25 +7,25 @@ public class IrisUtils {
 
     public boolean hasIrisDescendant(String codeCommune) {
         String sparqlQuery = String.format(
-                "SELECT DISTINCT ?type\n"
-                        + "FROM <http://rdf.insee.fr/graphes/geo/cog>\n"
-                        + "WHERE {\n"
-                        + "    {\n"
-                        + "        ?origine a igeo:Commune ;\n"
-                        + "        igeo:codeINSEE \"%s\" .\n"
-                        + "    }\n"
-                        + "    UNION\n"
-                        + "    {\n"
-                        + "        ?origine a igeo:ArrondissementMunicipal ;\n"
-                        + "        igeo:codeINSEE \"%s\" .\n"
-                        + "    }\n"
-                        + "    ?uri igeo:subdivisionDirecteDe+ ?origine .\n"
-                        + "    ?uri a ?type .\n"
-                        + "}\n"
-                        + "ORDER BY ?type", codeCommune, codeCommune);
+                "PREFIX igeo: <http://rdf.insee.fr/def/geo#>\n" +
+                        "ASK FROM <http://rdf.insee.fr/graphes/geo/cog>\n" +
+                        "WHERE {\n" +
+                        "    {\n" +
+                        "        ?origine a igeo:Commune ;\n" +
+                        "        igeo:codeINSEE \"%s\" .\n" +
+                        "    }\n" +
+                        "    UNION\n" +
+                        "    {\n" +
+                        "        ?origine a igeo:ArrondissementMunicipal ;\n" +
+                        "        igeo:codeINSEE \"%s\" .\n" +
+                        "    }\n" +
+                        "    ?uri igeo:subdivisionDirecteDe+ ?origine .\n" +
+                        "    ?uri a ?type .\n" +
+                        "    FILTER(STRENDS(STR(?type), \"#Iris\"))\n" +
+                        "}\n",
+                codeCommune, codeCommune);
 
-        var type=this.sparqlUtils.executeSparqlQuery(sparqlQuery);
-        return  type.endsWith("#Iris\r\n");
+        return this.sparqlUtils.executeAskQuery(sparqlQuery);
     }
 
 }


### PR DESCRIPTION
Adding the "Quartiers prioritaires de la ville" to the database revealed that tis code : `type=this.sparqlUtils.executeSparqlQuery(sparqlQuery) `
returns the different types obtained by the hasIrisDescendant query in a single line, which poses a problem. This query returns the descendants of the "Commune" (first 5 digits of the Iris code), and if one of the types is Iris, then we want type to be true, otherwise false.
If the query returns an Iris type and a QPV (Quartiers prioritaires de la ville) type, then the string type ends with #QPV and not #Iris (the different types being sorted alphabetically), and therefore returns false instead of true.

OK for iris 010040101  010020000  691230000 (not found)

